### PR TITLE
Fixing the Attachment Node size for MK1 parts 

### DIFF
--- a/GameData/DaMichel/CargoBays/Parts/125/dcb-125-1.cfg
+++ b/GameData/DaMichel/CargoBays/Parts/125/dcb-125-1.cfg
@@ -17,8 +17,8 @@ PART
 	bulkheadProfiles = size1, srf
 
 	attachRules = 1,1,1,1,0
-	node_stack_top = 0.0, 0.5, 0.0, 0.0, 1.0, 0.0, 1
-	node_stack_bottom = 0.0, -0.5, 0.0, 0.0, -1.0, 0.0, 1
+	node_stack_top = 0.0, 0.5, 0.0, 0.0, 1.0, 0.0, 0
+	node_stack_bottom = 0.0, -0.5, 0.0, 0.0, -1.0, 0.0, 0
 
 	node_stack_top2 = 0.0, 0.48, 0.0, 0.0, -1.0, 0.0, 0
 	node_stack_bottom2 = 0.0, -0.48, 0.0, 0.0, 1.0, 0.0, 0

--- a/GameData/DaMichel/CargoBays/Parts/125/dcb-125-2.cfg
+++ b/GameData/DaMichel/CargoBays/Parts/125/dcb-125-2.cfg
@@ -17,8 +17,8 @@ PART
 	bulkheadProfiles = size1, srf
 
 	attachRules = 1,1,1,1,0
-	node_stack_top = 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1
-	node_stack_bottom = 0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 1
+	node_stack_top = 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0
+	node_stack_bottom = 0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 0
 
 	node_stack_top2 = 0.0, 0.98, 0.0, 0.0, -1.0, 0.0, 0
 	node_stack_bottom2 = 0.0, -0.98, 0.0, 0.0, 1.0, 0.0, 0

--- a/GameData/DaMichel/CargoBays/Parts/125/dcb-125-4.cfg
+++ b/GameData/DaMichel/CargoBays/Parts/125/dcb-125-4.cfg
@@ -17,8 +17,8 @@ PART
 	bulkheadProfiles = size1, srf
 
 	attachRules = 1,1,1,1,0
-	node_stack_top = 0.0, 2.0, 0.0, 0.0, 1.0, 0.0, 1
-	node_stack_bottom = 0.0, -2.0, 0.0, 0.0, -1.0, 0.0, 1
+	node_stack_top = 0.0, 2.0, 0.0, 0.0, 1.0, 0.0, 0
+	node_stack_bottom = 0.0, -2.0, 0.0, 0.0, -1.0, 0.0, 0
 
 	node_stack_top2 = 0.0, 1.98, 0.0, 0.0, -1.0, 0.0, 0
 	node_stack_bottom2 = 0.0, -1.98, 0.0, 0.0, 1.0, 0.0, 0


### PR DESCRIPTION
(they should be 0, as Stock does).

Fixes: https://github.com/zer0Kerbal/CargoBays/issues/45